### PR TITLE
Bug Fix: OPTIONS and HEAD error in Requests-Mock support

### DIFF
--- a/stackinabox/tests/test_requests_mock.py
+++ b/stackinabox/tests/test_requests_mock.py
@@ -5,6 +5,7 @@ import json
 import logging
 import unittest
 
+import ddt
 import requests
 import six
 
@@ -48,6 +49,7 @@ class TestRequestsMockBasic(unittest.TestCase):
             self.assertEqual(res.text, 'Hello')
 
 
+@ddt.ddt
 class TestRequestMockAdvanced(unittest.TestCase):
 
     def setUp(self):
@@ -117,3 +119,22 @@ class TestRequestMockAdvanced(unittest.TestCase):
                                'alice=bob&joe=jane')
             self.assertEqual(res.status_code, 200)
             self.assertEqual(res.json(), expected_result)
+
+    @ddt.data(
+        ('head', 204, ''),
+        ('delete', 204, ''),
+        ('post', 200, 'created'),
+        ('put', 200, 'updated'),
+        ('patch', 200, 'patched'),
+        ('options', 200, 'options'),
+    )
+    @ddt.unpack
+    def test_extra_http_verbs(self, http_verb, response_status, response_body):
+        with stackinabox.util.requests_mock.activate():
+            stackinabox.util.requests_mock.requests_mock_registration(
+                'localhost')
+
+            method_call = getattr(requests, http_verb)
+            res = method_call('http://localhost/advanced/')
+            self.assertEqual(res.status_code, response_status)
+            self.assertEqual(res.text, response_body)

--- a/stackinabox/util/requests_mock/core.py
+++ b/stackinabox/util/requests_mock/core.py
@@ -214,13 +214,13 @@ def requests_get(url, **kwargs):
 def requests_options(url, **kwargs):
     """Requests-mock requests.options wrapper."""
     kwargs.setdefault('allow_redirects', True)
-    return reuests_request('options', url, **kwargs)
+    return requests_request('options', url, **kwargs)
 
 
 def requests_head(url, **kwargs):
     """Requests-mock requests.head wrapper."""
     kwargs.setdefault('allow_redirects', False)
-    return reuests_request('options', url, **kwargs)
+    return requests_request('head', url, **kwargs)
 
 
 def requests_post(url, data=None, json=None, **kwargs):


### PR DESCRIPTION
- Bug Fix: Requests-Mock support had a couple minor but highly
  impacting bugs in the HEAD and OPTIONS HTTP Verb support. This
  corrects the bugs and adds some more unit testing to confirm
  it's fixed.