### PR TITLE
Bugfix dependencies

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,4 +7,4 @@ exclude_lines =
     raise NotImplementedError
 
 [run]
-omit = *tests*
+omit = *tests* stackinabox/tests*

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,18 @@ matrix:
           env: TEST_SUITE=suite_3_4 TOX_ENV=pep8
         - python: "2.7"
           env: TEST_SUITE=suite_2_7 TOX_ENV=docs
+        - python: "2.7"
+          env: TEST_SUITE=suite_2_7 TOX_ENV=py27-httpretty
+        - python: "3.6"
+          env: TEST_SUITE=suite_3_6 TOX_ENV=py36-httpretty
+        - python: "2.7"
+          env: TEST_SUITE=suite_2_7 TOX_ENV=py27-requests-mock
+        - python: "3.6"
+          env: TEST_SUITE=suite_3_6 TOX_ENV=py36-requests-mock
+        - python: "2.7"
+          env: TEST_SUITE=suite_2_7 TOX_ENV=py27-responses
+        - python: "3.6"
+          env: TEST_SUITE=suite_3_6 TOX_ENV=py36-responses
 
 sudo: required
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
         - python: "2.7"
           env: TEST_SUITE=suite_2_7 TOX_ENV=docs
 
+sudo: required
 before_install:
   - sudo apt-get install build-essential python-dev
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author='Benjamen R. Meyer',
     author_email='bm_witness@yahoo.com',
     install_requires=REQUIRES,
-    extra_requests=EXTRA_REQUIRES,
+    extras_require=EXTRA_REQUIRES,
     test_suite='stackinabox',
     packages=find_packages(exclude=['tests*', 'stackinabox/tests']),
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,11 @@ import sys
 from setuptools import setup, find_packages
 
 REQUIRES = ['six']
+EXTRA_REQUIRES = {
+    'httpretty': ['httpretty==0.8.6'],
+    'requests-mock': ['requests-mock'],
+    'responses': ['responses>=0.4.0']
+}
 
 setup(
     name='stackinabox',
@@ -12,6 +17,7 @@ setup(
     author='Benjamen R. Meyer',
     author_email='bm_witness@yahoo.com',
     install_requires=REQUIRES,
+    extra_requests=EXTRA_REQUIRES,
     test_suite='stackinabox',
     packages=find_packages(exclude=['tests*', 'stackinabox/tests']),
     zip_safe=True,

--- a/stackinabox/stack.py
+++ b/stackinabox/stack.py
@@ -304,6 +304,7 @@ class StackInABox(object):
 
         return obj
 
+
 # Thread local instance of StackInABox
 local_store = threading.local()
 local_store.instance = StackInABox()

--- a/stackinabox/tests/test_version.py
+++ b/stackinabox/tests/test_version.py
@@ -29,8 +29,8 @@ class TestVersionMatch(unittest.TestCase):
             for line in input_data:
                 ln = line.strip()
                 if ln.startswith('version='):
-                    l = ln.replace("'", '', 2).replace(',', '')
-                    version_setup = l.split('=')[1]
+                    ln_parts = ln.replace("'", '', 2).replace(',', '')
+                    version_setup = ln_parts.split('=')[1]
                     break
 
         self.assertEqual(version_source, version_setup)

--- a/stackinabox/util/requests_mock/core.py
+++ b/stackinabox/util/requests_mock/core.py
@@ -132,7 +132,7 @@ class RequestMockCallable(object):
             try:
                 json_data = json.dumps(text_data)
                 text_data = json_data
-            except:
+            except Exception:
                 json_data = None
                 text_data = body
 

--- a/stackinabox/util/requests_mock/core.py
+++ b/stackinabox/util/requests_mock/core.py
@@ -12,7 +12,6 @@ import sys
 import threading
 import types
 
-import mock
 import requests
 from requests import Session
 from requests.adapters import HTTPAdapter

--- a/tools/pep8-requirements.txt
+++ b/tools/pep8-requirements.txt
@@ -1,2 +1,2 @@
 setuptools>=1.1.6
-pep8
+pycodestyle

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -3,7 +3,6 @@ ddt
 httpretty==0.8.6
 nose
 nose-exclude
-pep8
 requests
 requests-mock
 responses>=0.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=1.8
-envlist = py27,pypy,{py34,py35,py36},pep8,docs
+envlist = py27,pypy,{py34,py35,py36},py27-httpretty,py36-httpretty,py27-requests-mock,py36-requests-mock,py27-responses,py36-responses,pep8,docs
 skip_missing_interpreters=True
 
 [testenv]
@@ -25,7 +25,42 @@ commands =
     docs: sphinx-build -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
     docs: doc8 --allow-long-titles docs/
 setenv =
-    py34,py35,py36: VIRTUAL_ENV={envdir} LC_ALL = en_US.utf-8
+    py34,py35,py36,py36-httpretty,py36-requests-mock,py36-responses: VIRTUAL_ENV={envdir} LC_ALL = en_US.utf-8
+
+# Unfortunately the below doesn't seem to integrate well into the form above
+# but it's valuable for testing the setup with extra dependencies to make sure things install right
+[testenv:py27-httpretty]
+basepython = python2.7
+deps = .[httpretty]
+commands = python -c "import stackinabox.util.httpretty"
+
+[testenv:py36-httpretty]
+basepython = python3.6
+deps = .[httpretty]
+commands = python -c "import stackinabox.util.httpretty"
+setenv ={envdir} LC_ALL = en_US.utf-8
+
+[testenv:py27-requests-mock]
+basepython = python2.7
+deps = .[requests-mock]
+commands = python -c "import stackinabox.util.requests_mock"
+
+[testenv:py36-requests-mock]
+basepython = python3.6
+deps = .[requests-mock]
+commands = python -c "import stackinabox.util.requests_mock"
+setenv ={envdir} LC_ALL = en_US.utf-8
+
+[testenv:py27-responses]
+basepython = python2.7
+deps = .[responses]
+commands = python -c "import stackinabox.util.responses"
+
+[testenv:py36-responses]
+basepython = python3.6
+deps = .[responses]
+commands = python -c "import stackinabox.util.responses"
+setenv ={envdir} LC_ALL = en_US.utf-8
 
 [doc8]
 extensions = rst

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     docs: -r{toxinidir}/tools/docs-requirements.txt
 commands =
     py27,pypy,py34,py35,py36: nosetests {posargs}
-    pep8: pep8 --exclude=.tox,dist,doc,docs,*env*,.*env*,build --ignore=E128
+    pep8: pycodestyle --exclude=.tox,dist,doc,docs,*env*,.*env*,build --ignore=E128
     docs: sphinx-build -b html -d {envtmpdir}/doctrees docs docs/_build/html
     docs: sphinx-build -b latex -d {envtmpdir}/doctrees docs docs/_build/latex
     docs: sphinx-build -b doctest -d {envtmpdir}/doctrees docs docs/_build/html


### PR DESCRIPTION
- Bug Fix: request-mock support accidentally imported `mock`
- Bug Fix: Corrected coverage configuration to ignore tests (again)
- Bug Fix: Corrected the configuration to specify optional dependencies
- Bug Fix: pep8 project got renamed to pycodestyle
- Bug Fix: updated changes per pycodestyle
- Bug Fix: corrected testing dependencies, only pep8 config needs the pycodestyle dependency not the general tests

Closes #65 #67 