### PR TITLE
Bug Fix: Dependency Alert

### DIFF
--- a/tools/docs-requirements.txt
+++ b/tools/docs-requirements.txt
@@ -1,6 +1,6 @@
 doc8==0.8.0
 httpretty==0.8.6
-requests==2.18.4
+requests==2.21.0
 requests-mock==1.4.0
 responses>=0.4.0
 six==1.11.0

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -3,7 +3,7 @@ ddt==1.1.2
 httpretty==0.8.6
 pytest==3.3.2
 pytest-cov==2.5.1
-requests==2.18.4
+requests==2.21.0
 requests-mock==1.4.0
 responses>=0.4.0
 six==1.11.0


### PR DESCRIPTION
- Bug Fix: Updated Requests version used in testing due to CVE.
  This would have in no way impacted anyone *using* StackInABox
  with their tooling as Requets is not a direct dependency of
  StackInABox. This only affects the tox tests and therefore the
  CVE isn't really an issue for StackInABox. Still, updating for
  safety.