### PR TITLE
Ensure trailing slashes in session.mount() URLs

### DIFF
--- a/stackinabox/util/requests_mock/core.py
+++ b/stackinabox/util/requests_mock/core.py
@@ -17,13 +17,17 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.response import HTTPResponse
 import requests_mock
-import requests_mock.compat
 import requests_mock.response
 import six
 
 from stackinabox.stack import StackInABox
 from stackinabox.util import deprecator
 from stackinabox.util.requests_mock import reqcallable
+
+try:
+    import requests_mock.compat
+except ImportError:
+    pass
 
 
 logger = logging.getLogger(__name__)

--- a/stackinabox/util/requests_mock/core.py
+++ b/stackinabox/util/requests_mock/core.py
@@ -52,6 +52,9 @@ def session_registration(uri, session):
         reqcallable.RequestMockCallable(uri)
     )
 
+    if not uri.endswith('/'):
+        uri += '/'
+
     # Tell the session about the adapter and the URI
     session.mount('http://{0}'.format(uri), StackInABox.hold_out('adapter'))
     session.mount('https://{0}'.format(uri), StackInABox.hold_out('adapter'))


### PR DESCRIPTION
### Description
While reviewing the documentation for Python Requests, I noticed this recommendation:

> The adapter will be chosen based on a longest prefix match. Be mindful prefixes such as http://localhost will also match http://localhost.other.com or http://localhost@other.com. It's recommended to terminate full hostnames with a /.

I know that the code work great and do their job, but ensuring trailing slashes would align them with the docs and make the URL prefixes more precise.

### Changes
```python
# Add this before mounting
if not uri.endswith('/'):
    uri += '/'

# Then use the updated uri
session.mount('http://{0}'.format(uri), StackInABox.hold_out('adapter'))
session.mount('https://{0}'.format(uri), StackInABox.hold_out('adapter'))
```

This ensures the URI always has a trailing slash, providing consistent behavior regardless of how the URI was originally provided.